### PR TITLE
Added copyright to all *.go and *.py files

### DIFF
--- a/core/db/db.go
+++ b/core/db/db.go
@@ -1,3 +1,6 @@
+/*
+Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+*/
 package db
 
 import (

--- a/core/db/db.go
+++ b/core/db/db.go
@@ -1,5 +1,25 @@
 /*
-Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+MIT License
+
+Copyright (c) 2021 fall2021-csc510-group40
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 */
 package db
 

--- a/core/formatter/formatter.go
+++ b/core/formatter/formatter.go
@@ -1,5 +1,25 @@
 /*
-Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+MIT License
+
+Copyright (c) 2021 fall2021-csc510-group40
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 */
 package formatter
 

--- a/core/formatter/formatter.go
+++ b/core/formatter/formatter.go
@@ -1,3 +1,6 @@
+/*
+Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+*/
 package formatter
 
 import (

--- a/core/main.go
+++ b/core/main.go
@@ -1,3 +1,6 @@
+/*
+Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+*/
 package main
 
 import (

--- a/core/schema/schema.go
+++ b/core/schema/schema.go
@@ -1,3 +1,6 @@
+/*
+Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+*/
 package schema
 
 import (

--- a/core/schema/schema.go
+++ b/core/schema/schema.go
@@ -1,5 +1,25 @@
 /*
-Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+MIT License
+
+Copyright (c) 2021 fall2021-csc510-group40
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 */
 package schema
 

--- a/core/schema/schema_test.go
+++ b/core/schema/schema_test.go
@@ -1,3 +1,6 @@
+/*
+Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+*/
 package schema
 
 import "testing"

--- a/core/schema/schema_test.go
+++ b/core/schema/schema_test.go
@@ -1,5 +1,25 @@
 /*
-Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+MIT License
+
+Copyright (c) 2021 fall2021-csc510-group40
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 */
 package schema
 

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -1,5 +1,24 @@
-/*
-Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+/*MIT License
+
+Copyright (c) 2021 fall2021-csc510-group40
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 */
 package server
 

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -1,3 +1,6 @@
+/*
+Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+*/
 package server
 
 import (

--- a/core/source/acm.go
+++ b/core/source/acm.go
@@ -1,5 +1,25 @@
 /*
-Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+MIT License
+
+Copyright (c) 2021 fall2021-csc510-group40
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 */
 package source
 

--- a/core/source/acm.go
+++ b/core/source/acm.go
@@ -1,3 +1,6 @@
+/*
+Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+*/
 package source
 
 import (

--- a/core/source/crossref.go
+++ b/core/source/crossref.go
@@ -1,5 +1,25 @@
 /*
-Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+MIT License
+
+Copyright (c) 2021 fall2021-csc510-group40
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 */
 package source
 

--- a/core/source/crossref.go
+++ b/core/source/crossref.go
@@ -1,3 +1,6 @@
+/*
+Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+*/
 package source
 
 import (

--- a/core/source/source.go
+++ b/core/source/source.go
@@ -1,5 +1,24 @@
-/*
-Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+/*MIT License
+
+Copyright (c) 2021 fall2021-csc510-group40
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 */
 package source
 

--- a/core/source/source.go
+++ b/core/source/source.go
@@ -1,3 +1,6 @@
+/*
+Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+*/
 package source
 
 import "core/schema"

--- a/core/util/util.go
+++ b/core/util/util.go
@@ -1,5 +1,25 @@
 /*
-Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+MIT License
+
+Copyright (c) 2021 fall2021-csc510-group40
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 */
 package util
 

--- a/core/util/util.go
+++ b/core/util/util.go
@@ -1,3 +1,6 @@
+/*
+Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+*/
 package util
 
 import (

--- a/core/util/util_test.go
+++ b/core/util/util_test.go
@@ -1,5 +1,25 @@
 /*
-Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+MIT License
+
+Copyright (c) 2021 fall2021-csc510-group40
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 */
 package util
 

--- a/core/util/util_test.go
+++ b/core/util/util_test.go
@@ -1,3 +1,6 @@
+/*
+Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+*/
 package util
 
 import (

--- a/telegram-bot/api.py
+++ b/telegram-bot/api.py
@@ -1,3 +1,6 @@
+"""
+Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+"""
 import requests
 
 

--- a/telegram-bot/api.py
+++ b/telegram-bot/api.py
@@ -1,5 +1,25 @@
 """
-Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+MIT License
+
+Copyright (c) 2021 fall2021-csc510-group40
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 """
 import requests
 

--- a/telegram-bot/keyboards.py
+++ b/telegram-bot/keyboards.py
@@ -1,5 +1,25 @@
 """
-Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+MIT License
+
+Copyright (c) 2021 fall2021-csc510-group40
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 """
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 import emoji

--- a/telegram-bot/keyboards.py
+++ b/telegram-bot/keyboards.py
@@ -1,3 +1,6 @@
+"""
+Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+"""
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 import emoji
 

--- a/telegram-bot/main.py
+++ b/telegram-bot/main.py
@@ -1,3 +1,6 @@
+"""
+Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+"""
 import json
 
 from telegram.ext import Updater, MessageHandler, CallbackQueryHandler, CallbackContext, Filters, ConversationHandler

--- a/telegram-bot/main.py
+++ b/telegram-bot/main.py
@@ -1,5 +1,25 @@
 """
-Copyright (c) 2021 contributors of the Citatron-5000 Project. All Rights Reserved
+MIT License
+
+Copyright (c) 2021 fall2021-csc510-group40
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 """
 import json
 


### PR DESCRIPTION
All code files that are either in Golang or Python now have an included copyright message for documentation purposes